### PR TITLE
HCP Migration of Workspaces in trujillo-adam/learn-terraform-migrate repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# These lines were added by the tf-migrate CLI tool
+_hcp-migrate-configs/
+_hcp-migrate-configs-*/
+!_hcp-migrate-configs*/terraform.tfstate*
+.terraform.lock.*

--- a/_hcp-migrate-configs/terraform.tfstate
+++ b/_hcp-migrate-configs/terraform.tfstate
@@ -1,0 +1,444 @@
+{
+  "version": 4,
+  "terraform_version": "1.10.5",
+  "serial": 14,
+  "lineage": "f87b4da4-ab80-928f-bd16-152418f29110",
+  "outputs": {
+    "count_dir_skipped": {
+      "value": 1,
+      "type": "number"
+    },
+    "list_of_new_project_ids": {
+      "value": [
+        "prj-hUtkWYMN2Zwm32at",
+        "prj-SCsZMFXiVWqLyD43"
+      ],
+      "type": [
+        "tuple",
+        [
+          "string",
+          "string"
+        ]
+      ]
+    },
+    "list_of_new_project_names": {
+      "value": [
+        "example_compute",
+        "example_storage"
+      ],
+      "type": [
+        "tuple",
+        [
+          "string",
+          "string"
+        ]
+      ]
+    }
+  },
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "tfe_project",
+      "name": "list_of_new_projects",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfe\"]",
+      "instances": [
+        {
+          "index_key": "example_compute",
+          "schema_version": 0,
+          "attributes": {
+            "description": "Created by Terrafrom Migrate from the Github Repository: trujillo-adam/learn-terraform-migrate",
+            "id": "prj-hUtkWYMN2Zwm32at",
+            "name": "example_compute",
+            "organization": "hashicorp-training"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        },
+        {
+          "index_key": "example_storage",
+          "schema_version": 0,
+          "attributes": {
+            "description": "Created by Terrafrom Migrate from the Github Repository: trujillo-adam/learn-terraform-migrate",
+            "id": "prj-SCsZMFXiVWqLyD43",
+            "name": "example_storage",
+            "organization": "hashicorp-training"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"example/compute\"]",
+      "mode": "data",
+      "type": "tfe_project",
+      "name": "project",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfe\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "description": "Created by Terrafrom Migrate from the Github Repository: trujillo-adam/learn-terraform-migrate",
+            "id": "prj-hUtkWYMN2Zwm32at",
+            "name": "example_compute",
+            "organization": "hashicorp-training",
+            "workspace_ids": []
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"example/compute\"]",
+      "mode": "managed",
+      "type": "tfe_workspace",
+      "name": "workspaces",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfe\"]",
+      "instances": [
+        {
+          "index_key": "default",
+          "schema_version": 1,
+          "attributes": {
+            "agent_pool_id": "",
+            "allow_destroy_plan": true,
+            "assessments_enabled": false,
+            "auto_apply": false,
+            "auto_apply_run_trigger": false,
+            "description": "",
+            "execution_mode": "remote",
+            "file_triggers_enabled": true,
+            "force_delete": false,
+            "global_remote_state": false,
+            "html_url": "https://app.terraform.io/app/hashicorp-training/workspaces/example_compute_default",
+            "id": "ws-hXWoR92ahWnW2Wnb",
+            "ignore_additional_tag_names": null,
+            "name": "example_compute_default",
+            "operations": true,
+            "organization": "hashicorp-training",
+            "project_id": "prj-hUtkWYMN2Zwm32at",
+            "queue_all_runs": false,
+            "remote_state_consumer_ids": [],
+            "resource_count": 0,
+            "source_name": "Tf-Migrate",
+            "source_url": "https://github.com/hashicorp/tf-migrate",
+            "speculative_enabled": true,
+            "ssh_key_id": "",
+            "structured_run_output_enabled": true,
+            "tag_names": [
+              "example_compute"
+            ],
+            "terraform_version": "1.10.5",
+            "trigger_patterns": null,
+            "trigger_prefixes": null,
+            "vcs_repo": [],
+            "working_directory": ""
+          },
+          "sensitive_attributes": [],
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ==",
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "tfe_project.list_of_new_projects"
+          ]
+        },
+        {
+          "index_key": "testing",
+          "schema_version": 1,
+          "attributes": {
+            "agent_pool_id": "",
+            "allow_destroy_plan": true,
+            "assessments_enabled": false,
+            "auto_apply": false,
+            "auto_apply_run_trigger": false,
+            "description": "",
+            "execution_mode": "remote",
+            "file_triggers_enabled": true,
+            "force_delete": false,
+            "global_remote_state": false,
+            "html_url": "https://app.terraform.io/app/hashicorp-training/workspaces/example_compute_testing",
+            "id": "ws-pRWTLdusteAQF8yj",
+            "ignore_additional_tag_names": null,
+            "name": "example_compute_testing",
+            "operations": true,
+            "organization": "hashicorp-training",
+            "project_id": "prj-hUtkWYMN2Zwm32at",
+            "queue_all_runs": false,
+            "remote_state_consumer_ids": [],
+            "resource_count": 0,
+            "source_name": "Tf-Migrate",
+            "source_url": "https://github.com/hashicorp/tf-migrate",
+            "speculative_enabled": true,
+            "ssh_key_id": "",
+            "structured_run_output_enabled": true,
+            "tag_names": [
+              "example_compute"
+            ],
+            "terraform_version": "1.10.5",
+            "trigger_patterns": null,
+            "trigger_prefixes": null,
+            "vcs_repo": [],
+            "working_directory": ""
+          },
+          "sensitive_attributes": [],
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ==",
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"example/compute\"]",
+      "mode": "managed",
+      "type": "tfmigrate_state_migration",
+      "name": "state-migration",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfmigrate\"]",
+      "instances": [
+        {
+          "index_key": "default",
+          "schema_version": 0,
+          "attributes": {
+            "directory_path": "/Users/hashicorp-at/learn-terraform-migrate/example/compute",
+            "local_workspace": "default",
+            "org": "hashicorp-training",
+            "tfc_workspace": "example_compute_default"
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "module.workspace_and_variables.tfmigrate_terraform_init.terraform_init",
+            "tfe_project.list_of_new_projects"
+          ]
+        },
+        {
+          "index_key": "testing",
+          "schema_version": 0,
+          "attributes": {
+            "directory_path": "/Users/hashicorp-at/learn-terraform-migrate/example/compute",
+            "local_workspace": "testing",
+            "org": "hashicorp-training",
+            "tfc_workspace": "example_compute_testing"
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "module.workspace_and_variables.tfmigrate_terraform_init.terraform_init",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"example/compute\"]",
+      "mode": "managed",
+      "type": "tfmigrate_terraform_init",
+      "name": "terraform_init",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfmigrate\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "directory_path": "/Users/hashicorp-at/learn-terraform-migrate/example/compute",
+            "summary": "Terraform Init Completed."
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"example/compute\"]",
+      "mode": "managed",
+      "type": "tfmigrate_update_backend",
+      "name": "update-backend",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfmigrate\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "backend_file_name": "main.tf",
+            "directory_path": "/Users/hashicorp-at/learn-terraform-migrate/example/compute",
+            "org": "hashicorp-training",
+            "project": "example_compute",
+            "tags": [
+              "example_compute"
+            ],
+            "workspace_map": {
+              "default": "example_compute_default",
+              "testing": "example_compute_testing"
+            }
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "module.workspace_and_variables.tfmigrate_state_migration.state-migration",
+            "module.workspace_and_variables.tfmigrate_terraform_init.terraform_init",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"example/storage\"]",
+      "mode": "data",
+      "type": "tfe_project",
+      "name": "project",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfe\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "description": "Created by Terrafrom Migrate from the Github Repository: trujillo-adam/learn-terraform-migrate",
+            "id": "prj-SCsZMFXiVWqLyD43",
+            "name": "example_storage",
+            "organization": "hashicorp-training",
+            "workspace_ids": []
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"example/storage\"]",
+      "mode": "managed",
+      "type": "tfe_workspace",
+      "name": "workspaces",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfe\"]",
+      "instances": [
+        {
+          "index_key": "default",
+          "schema_version": 1,
+          "attributes": {
+            "agent_pool_id": "",
+            "allow_destroy_plan": true,
+            "assessments_enabled": false,
+            "auto_apply": false,
+            "auto_apply_run_trigger": false,
+            "description": "",
+            "execution_mode": "remote",
+            "file_triggers_enabled": true,
+            "force_delete": false,
+            "global_remote_state": false,
+            "html_url": "https://app.terraform.io/app/hashicorp-training/workspaces/example_storage_default",
+            "id": "ws-sLQwAML2ehqBZ96x",
+            "ignore_additional_tag_names": null,
+            "name": "example_storage_default",
+            "operations": true,
+            "organization": "hashicorp-training",
+            "project_id": "prj-SCsZMFXiVWqLyD43",
+            "queue_all_runs": false,
+            "remote_state_consumer_ids": [],
+            "resource_count": 0,
+            "source_name": "Tf-Migrate",
+            "source_url": "https://github.com/hashicorp/tf-migrate",
+            "speculative_enabled": true,
+            "ssh_key_id": "",
+            "structured_run_output_enabled": true,
+            "tag_names": [
+              "example_storage"
+            ],
+            "terraform_version": "1.10.5",
+            "trigger_patterns": null,
+            "trigger_prefixes": null,
+            "vcs_repo": [],
+            "working_directory": ""
+          },
+          "sensitive_attributes": [],
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ==",
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"example/storage\"]",
+      "mode": "managed",
+      "type": "tfmigrate_state_migration",
+      "name": "state-migration",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfmigrate\"]",
+      "instances": [
+        {
+          "index_key": "default",
+          "schema_version": 0,
+          "attributes": {
+            "directory_path": "/Users/hashicorp-at/learn-terraform-migrate/example/storage",
+            "local_workspace": "default",
+            "org": "hashicorp-training",
+            "tfc_workspace": "example_storage_default"
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "module.workspace_and_variables.tfmigrate_terraform_init.terraform_init",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"example/storage\"]",
+      "mode": "managed",
+      "type": "tfmigrate_terraform_init",
+      "name": "terraform_init",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfmigrate\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "directory_path": "/Users/hashicorp-at/learn-terraform-migrate/example/storage",
+            "summary": "Terraform Init Completed."
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"example/storage\"]",
+      "mode": "managed",
+      "type": "tfmigrate_update_backend",
+      "name": "update-backend",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfmigrate\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "backend_file_name": "main.tf",
+            "directory_path": "/Users/hashicorp-at/learn-terraform-migrate/example/storage",
+            "org": "hashicorp-training",
+            "project": "example_storage",
+            "tags": [
+              "example_storage"
+            ],
+            "workspace_map": {
+              "default": "example_storage_default"
+            }
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "module.workspace_and_variables.tfmigrate_state_migration.state-migration",
+            "module.workspace_and_variables.tfmigrate_terraform_init.terraform_init",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/example/compute/main.tf
+++ b/example/compute/main.tf
@@ -6,8 +6,13 @@ terraform {
     }
   }
 
-  backend "s3" {
-    key = "learn-terraform-migrate/compute/frontend/terraform.tfstate"
+  cloud {
+    organization = "hashicorp-training"
+    hostname     = "app.terraform.io"
+    workspaces {
+      project = "example_compute"
+      tags    = ["example_compute"]
+    }
   }
 }
 

--- a/example/storage/main.tf
+++ b/example/storage/main.tf
@@ -6,8 +6,13 @@ terraform {
     }
   }
 
-  backend "s3" {
-    key = "learn-terraform-migrate/example/storage/terraform.tfstate"
+  cloud {
+    organization = "hashicorp-training"
+    hostname     = "app.terraform.io"
+    workspaces {
+      project = "example_storage"
+      name    = "example_storage_default"
+    }
   }
 }
 


### PR DESCRIPTION
This PR is created by TFMigrate CLI to migrate the Workspaces from the repository trujillo-adam/learn-terraform-migrate to the app.terraform.io.